### PR TITLE
Added mermaid diagram for the basic agent loop to the Design Decision Register

### DIFF
--- a/DESIGN_DECISION_REGISTER.md
+++ b/DESIGN_DECISION_REGISTER.md
@@ -39,7 +39,40 @@ There are a few tricks/hacks when it comes to using the basic agent that may be 
 
 *   The basic agent [documentation](https://inspect.ai-safety-institute.org.uk/agents.html#sec-basic-agent).
 *   The `basic_agent()` code [implementation](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/solver/_basic_agent.py).
-*   The basic agent [flow chart](https://sharing.clickup.com/9011772876/wb/h/8cj9fec-10791/db9aa0776345344).
+*   The basic agent flow chart (see mermaid diagram below)
+
+```mermaid
+flowchart TD
+    Start["Initialize system message, available resources, token limits, and max attempts"] --> Generate
+
+    subgraph Basic Agent Loop
+        Generate["Generate"]
+        Generate --> ModelTool
+        ModelTool{"Has the model called a tool?"}
+        
+        ModelTool -->|Yes| SubmitTool{"Was the submit tool called?"}
+        ModelTool -->|No| AppendContinue["Append continue ChatMessage to TaskState messages"]
+        AppendContinue --> LimitReached{"Has a limit been reached?"}
+        
+        SubmitTool -->|Yes| MaxAttempts{"Has max attempts been reached?"}
+        SubmitTool -->|No| LimitReached
+        
+        MaxAttempts -->|No| Score["Score answer"]
+        Score --> Correct{"Was the answer correct?"}
+        
+        Correct -->|No| AppendIncorrect["Append Incorrect ChatMessage to TaskState messages"]
+        AppendIncorrect --> LimitReached
+        
+        LimitReached -->|No| Generate
+    end
+    
+    MaxAttempts -->|Yes| Exit["Exit loop"]
+    Correct -->|Yes| Exit
+    LimitReached -->|Yes| Exit
+
+    classDef condition fill:#be133a,stroke:#8e0e2b
+    class MaxAttempts,Correct,LimitReached,Exit condition
+```
 
 Reasons why you may not be able to leverage the basic agent include (though these are typically out of scope for the MVP):
 

--- a/DESIGN_DECISION_REGISTER.md
+++ b/DESIGN_DECISION_REGISTER.md
@@ -1,33 +1,34 @@
 # Design Decision Register
 
-**_Intended audience:_** _Engineers, TPMs, Head of Engineering_
-
-**_Purpose:_** _A live document which collates design decisions & analysis for sharing across projects_
+> **_Intended audience:_** _Engineers, TPMs, Head of Engineering_
+> **_Purpose:_** _A live document which collates design decisions & analysis for sharing across projects_
 
 ## Resources
 
-Below are some of the key classes and functions that you will need to understand in order to build an evaluation in Inspect. The accompanying code and documentation (if defined) is hyperlinked for each component.
 
-*   **Task:** [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/_eval/task/task.py)
-*   **TaskState:** [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/solver/_task_state.py)
-*   **Dataset/Sample**: [documentation](https://inspect.ai-safety-institute.org.uk/datasets.html) | [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/dataset/_dataset.py)
-*   **Sandbox:** [documentation](https://inspect.ai-safety-institute.org.uk/sandboxing.html) | [code](https://github.com/UKGovernmentBEIS/inspect_ai/tree/main/src/inspect_ai/util/_sandbox)
-*   **Solver:** [documentation](https://inspect.ai-safety-institute.org.uk/solvers.html) | [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/solver/_solver.py)
-*   **Basic Agent:** [documentation](https://inspect.ai-safety-institute.org.uk/agents.html) | [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/solver/_basic_agent.py)
-*   **Scorer:** [documentation](https://inspect.ai-safety-institute.org.uk/scorers.html) | [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/scorer/_scorer.py)
-    *   **Score:** [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/scorer/_metric.py)
-    *   **Metric:** [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/scorer/_metric.py) | [documentation](https://inspect.ai-safety-institute.org.uk/scorers.html#scoring-metrics)
 
-## Agent Design
+> [!NOTE] **Below are some of the key classes and functions that you will need to understand in order to build an evaluation in Inspect. The accompanying code and documentation (if defined) is hyperlinked for each component.**
+>*   **Task:** [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/_eval/task/task.py)
+>*   **TaskState:** [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/solver/_task_state.py)
+>*   **Dataset/Sample**: [documentation](https://inspect.ai-safety-institute.org.uk/datasets.html) | [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/dataset/_dataset.py)
+>*   **Sandbox:** [documentation](https://inspect.ai-safety-institute.org.uk/sandboxing.html) | [code](https://github.com/UKGovernmentBEIS/inspect_ai/tree/main/src/inspect_ai/util/_sandbox)
+>*   **Solver:** [documentation](https://inspect.ai-safety-institute.org.uk/solvers.html) | [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/solver/_solver.py)
+>*   **Basic Agent:** [documentation](https://inspect.ai-safety-institute.org.uk/agents.html) | [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/solver/_basic_agent.py)
+>*   **Scorer:** [documentation](https://inspect.ai-safety-institute.org.uk/scorers.html) | [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/scorer/_scorer.py)
+>    *   **Score:** [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/scorer/_metric.py)
+>    *   **Metric:** [code](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/scorer/_metric.py) | [documentation](https://inspect.ai-safety-institute.org.uk/scorers.html#scoring-metrics)
 
-### **There's a particular step or action that is causing the agent to perform badly on a (sub)task - should I build in additional affordances (tools) to help improve performance?**
+
+# Agent Design
+
+## **There's a particular step or action that is causing the agent to perform badly on a (sub)task - should I build in additional affordances (tools) to help improve performance?**
 
 Before adding in additional affordances, you should consider the following:
 
 *   Have you correctly identified the root cause of the bottleneck? Are there other parts of the evaluation that could be causing the agent to fail (i.e., environment is not set up properly, the message/token limits are too low, the task is not explained properly, the task is too complex and needs to be broken down into subtasks)?
 *   How does the additional affordance impact task difficulty? Does the tool trivialise the core capability being tested? (E.g. you are evaluating the coding abilities of an agent and prewrite Python scripts that fundamentally solve the coding challenge being tested)
 
-### **Can we use the basic agent, or do we need to use custom scaffolding?**
+## **Can we use the basic agent, or do we need to use custom scaffolding?**
 
 By default, you **must** always try and leverage the basic agent implemented in Inspect before considering custom agent scaffolding. We want to use the basic agent if it is sensible to do so as this will:
 
@@ -74,7 +75,7 @@ flowchart TD
     class MaxAttempts,Correct,LimitReached,Exit condition
 ```
 
-Reasons why you may not be able to leverage the basic agent include (though these are typically out of scope for the MVP):
+Reasons why you may not be able to leverage the basic agent include (though these are typically out of scope):
 
 *   **You** **need** **to add custom components** (solvers) to enhance the agent scaffolding (e.g. a Chain of Thought reasoning solver).
 *   **You need to add another exit condition** **to the agent loop** or need to remove/modify one of the existing exit conditions. Currently the basic agent loop is terminated if one of the following occurs:
@@ -82,7 +83,7 @@ Reasons why you may not be able to leverage the basic agent include (though thes
     *   The token or message limit has been reached.
     *   The agent agent's submitted answer is correct.
 
-### The submission logic on the basic agent requires the agent to submit an answer, but this doesn't make sense for my evaluation.
+## The submission logic on the basic agent requires the agent to submit an answer, but this doesn't make sense for my evaluation.
 
 _(For richer context) The basic agent submission functionality is designed to accept an "answer" from an agent which is evaluated for correctness. When the agent calls `submit`, the agent is scored using the task's configured `scorer`. A score of 1.0 (or a value that converts to 1.0 via the `score_value` function) indicates success, ending the agent loop. Otherwise, the agent receives an "incorrect" message prompting it to try again._
 
@@ -93,10 +94,9 @@ This submission logic can be confusing when your task doesn't involve finding a 
 
 Further, the scoring mechanism is flexible. `score(state)` evaluates based on the task's `scorer` , which doesn't have to use the answer submitted by the agent. As long as your `scorer` returns 1.0 for success (or your `score_value` function maps successful scores to 1.0), the submission flow works.
 
+
 ```python
-INCORRECT_MESSAGE = """
-Your submission failed unit tests. Please revise your changes and try again.
-"""
+INCORRECT_MESSAGE = "Your submission failed unit tests. Please revise your changes and try again."
 SUBMIT_DESCRIPTION = "Use the word 'submit' to submit your code changes."
 
 def default_solver() -> Solver:
@@ -106,9 +106,9 @@ def default_solver() -> Solver:
     )
 ```
 
-## Datasets & Resources
+# Datasets & Resources
 
-### Should I use an external dependency or (if possible) should I make this a persistent resource and save it in the evaluation module?
+## Should I use an external dependency or (if possible) should I make this a persistent resource and save it in the evaluation module?
 
 Per the [AS Evaluation Standard](https://ukgovernmentbeis.github.io/as-evaluation-standard/) under Setup and Dependencies, the evaluation should require minimal extra dependencies beyond those already in the template repo. If an external dependency is used, you should consider why the dependency is necessary and assess any potential risks of abandonment/ dependency decay.
 
@@ -126,9 +126,9 @@ Some reasons you may want to make a dependency persistent include:
 *   The dependency is simple enough to reimplement or mock
 *   The risk the dependency will be abandoned or unsupported is too high
 
-The versions of any dependencies required **must** be pinned.
+If your evaluation has any external dependencies, the versions of those dependencies **must** be pinned.
 
-### Should I use Inspect `Dataset` readers to handle datasets that will be used in the evaluation, but wont be used as the `Dataset` to run the `Task` **and** evaluate the model?
+## Should I use Inspect `Dataset` readers to handle datasets that will be used in the evaluation, but wont be used as the `Dataset` to run the `Task` **and** evaluate the model?
 
 You should only use the Inspect `Dataset` readers (such as `csv_dataset`, `json_dataset`, `hf_dataset`, etc) for loading datasets that will be used _as your evaluation dataset._ More clearly, `Dataset` objects are designed for running an evaluation on a model and should not be used to load any dataset besides the one that you will pass as the `dataset` on your `Task`.
 
@@ -141,7 +141,7 @@ There are a few reasons for this:
 
 Filtering, shuffling, and slicing functionalities provided by Inspect's `Dataset` class are also readily available in other Python libraries (such as `datasets`, `pandas`, and `numpy`).
 
-### How do I setup my `Dataset` if the evaluation only has one complex task instead of multiple samples to evaluate?
+## How do I setup my `Dataset` if the evaluation only has one complex task instead of multiple samples to evaluate?
 
 For agentic evaluations, the term "dataset" may seem misleading since you might only have one complex task rather than multiple examples to evaluate. In these cases, your `Dataset` should consist of just a single `Sample` where the `input` describes the task objectives and success criteria. You should then read this sample using `MemoryDataset` and pass this to the `Task`. See a very simple mocked example below:
 
@@ -166,9 +166,9 @@ def evaluation_task():
 
 ```
 
-## Scoring
+# Scoring
 
-### How do I turn my continuous score into a binary (pass/fail) metric?
+## How do I turn my continuous score into a binary (pass/fail) metric?
 
 There's no science to this, but here are some guiding principles:
 
@@ -176,7 +176,7 @@ There's no science to this, but here are some guiding principles:
 *   Consider phrasing your evaluation as a sentence: "if a model can pass this evaluation, then it can <do some behaviour>". Try to make the behaviour as real-world as possible: "do the job of a research assistant" is better than "perform data retrieval, paper summarization, and data preprocessing tasks upon prompting". Then ask yourself: at what threshold would a reasonable, well-informed person agree that this model satisfies that description?
 *   If your evaluation is specifically measuring a dangerous capability, or a proxy thereof, choose a threshold such that passing the evaluation means the agent more likely than not possesses this capability.
 
-### I want to collect scores throughout the evaluation run rather than just scoring some final agent output or answer. How can I do this?
+## I want to collect scores throughout the evaluation run rather than just scoring some final agent output or answer. How can I do this?
 
 You can capture intermediate scores throughout the evaluation by using a `Store`. The `TaskState` for each sample has a `Store` that can be used to collect any data throughout the evaluation. The `Store` an be accessed directly from the `TaskState` via `state.store` or can be accessed using the `store()` global function.
 
@@ -203,7 +203,7 @@ def some_tool() -> Tool:
         return "Hooray"
     return execute
 
-@scorer(metrics=[mean()])
+@scorer(metrics=[])
 def scorer():
    async def score(state: TaskState, target: Target) -> Score:
       # Get result
@@ -212,14 +212,13 @@ def scorer():
       # Now use results to score agent...
 ```
 
-### How can I define metrics when I only have one sample?
+## How can I define metrics when I only have one sample?
 
-`Metric` 's are typically calculated by aggregating `Score` values across multiple `Sample` 's into statistical measures, such as accuracy, mean, standard error, and other quantitative indicators of model performance. This can seem confusing or arbitrary when you only have one `Sample`. However, even if your dataset consists of only a single `Sample`, there is still benefit to defining metrics as these display in the top right corner of Inspect View and give richer context for your evaluation
+`Metric`'s are typically calculated by aggregating `Score` values across multiple `Sample`'s into statistical measures, such as accuracy, mean, standard error, and other quantitative indicators of model performance. This can seem confusing or arbitrary when you only have one `Sample`. However, even if your dataset consists of only a single `Sample`, there is still benefit to defining metrics as these display in the top right corner of Inspect View and give richer context for your evaluation
 
-*   **Inspect View Example**
-    
-    ![](https://t9011772876.p.clickup-attachments.com/t9011772876/0aba2379-01c9-4a41-afb0-f9d4d8f69b87/image.png)
-    
+>**Inspect View Example**:
+> ![](https://t9011772876.p.clickup-attachments.com/t9011772876/0aba2379-01c9-4a41-afb0-f9d4d8f69b87/image.png)
+
 For displaying metrics when you only have one `Sample`, you should calculate any metrics inside the `scorer` and then retrieve the metrics inside `@metric` decorated functions in one of two ways:
 
 1. Via the `score.value`. A `score.value` can be a dictionary, which means you can set a key/value pair for each of your metric values and retrieve them in the `@metric` function.
@@ -268,9 +267,9 @@ def test_task_has_only_one_sample():
     assert len(my_task().samples) == 1
 ```
 
-## Sandbox
+# Sandbox
 
-### How should I configure my environment variables?
+## How should I configure my environment variables?
 
 You **should** put any environment variables needed in a `.env` file, inside the inner folder of your evaluation. For example, if your evaluation is called `my_eval` , you should place any environment variables in `my_eval/my_eval/.env` .
 
@@ -292,7 +291,7 @@ Just make sure to remove this block before submitting the code to AISI.
 
 You **must** document any required environment variables in your [README.md](http://README.md).
 
-### sandbox().exec() is returning an empty ExecResult. What should I do?
+## `sandbox().exec()` is returning an empty `ExecResult`. What should I do?
 
 Sometimes, strange things will happen when running commands inside the docker sandbox while inside a dev container. Concretely, suppose you are running Inspect from inside a Dev Container, and you've configured your task to use a Docker-based sandbox:
 


### PR DESCRIPTION
Summary of update:
- Added mermaid diagram showing basic agent loop (replacing link to basic agent loop whiteboard in ClickUp)
- Upgrades the headings (i.e. from H3 to H2, H2 to H1, etc) for easier clarity
- Added some block styling to highlight certain sections
- Cleaned up minor typo/grammar errors 